### PR TITLE
Use MOUSE_BUTTON_RIGHT to show selection window.

### DIFF
--- a/addons/godot_test_scene/test_scene_button.gd
+++ b/addons/godot_test_scene/test_scene_button.gd
@@ -10,6 +10,12 @@ func _on_pressed() -> void:
 	else:
 		show_selection_window("Select test scene path")
 
+func _on_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton\
+			and event.pressed\
+			and event.button_index == MOUSE_BUTTON_RIGHT:
+		show_selection_window("Select test scene path")
+
 func run_test_scene():
 	var current_scene := EditorInterface.get_edited_scene_root()
 	var test_scene_path := current_scene.get_meta(META_NAME)

--- a/addons/godot_test_scene/test_scene_button.tscn
+++ b/addons/godot_test_scene/test_scene_button.tscn
@@ -24,4 +24,5 @@ theme_override_styles/normal = SubResource("StyleBoxEmpty_ocjw8")
 icon = ExtResource("1_aa2ip")
 script = ExtResource("2_78f3v")
 
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]
 [connection signal="pressed" from="." to="." method="_on_pressed"]


### PR DESCRIPTION
Add a second, convenient way to (re-)set the test scene setting by just right click the button.